### PR TITLE
feat: add csv-clean CLI toolkit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -e .
+
+      - name: Run pytest
+        run: pytest

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+__pycache__/
+*.py[cod]
+*.egg-info/
+.venv/
+.env/
+.python-version
+out/
+.pytest_cache/
+.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+PYTHON ?= python3.11
+VENV ?= .venv
+PIP := $(VENV)/bin/pip
+PYTHON_BIN := $(VENV)/bin/python
+
+.PHONY: venv test run format lint
+
+venv:
+	$(PYTHON) -m venv $(VENV)
+	$(PIP) install --upgrade pip
+	$(PIP) install -r requirements.txt
+	$(PIP) install -e .
+
+test:
+	$(PYTHON_BIN) -m pytest
+
+run:
+	$(VENV)/bin/csv-clean --input examples/customers_small.csv --output-dir out
+
+format:
+	$(VENV)/bin/ruff check src tests --fix
+	$(VENV)/bin/black src tests
+
+lint:
+	$(VENV)/bin/ruff check src tests

--- a/README.md
+++ b/README.md
@@ -1,16 +1,115 @@
-## Hi there 👋
+# csv-clean
 
-<!--
-**Samko33/Samko33** is a ✨ _special_ ✨ repository because its `README.md` (this file) appears on your GitHub profile.
+Command-line CSV and Google-Sheets style deduplication that runs entirely on your laptop.
 
-Here are some ideas to get you started:
+## Why csv-clean?
+- ✅ Remove exact duplicates by email in seconds.
+- 🔍 Spot likely duplicates based on fuzzy matching of `name + city`.
+- 📦 Export three ready-to-share files: `clean.csv`, `duplicates.csv`, and `review.csv`.
+- 🧰 Batteries-included: sample data, tests, formatting, and CI.
 
-- 🔭 I’m currently working on ...
-- 🌱 I’m currently learning ...
-- 👯 I’m looking to collaborate on ...
-- 🤔 I’m looking for help with ...
-- 💬 Ask me about ...
-- 📫 How to reach me: ...
-- 😄 Pronouns: ...
-- ⚡ Fun fact: ...
--->
+## Installation
+The project targets Python 3.11. The easiest way to install is via [pipx](https://pipx.pypa.io/):
+
+```bash
+pipx install .
+```
+
+Alternatively, inside a virtual environment:
+
+```bash
+python3.11 -m venv .venv
+source .venv/bin/activate
+pip install -e .
+```
+
+All runtime dependencies are listed in `pyproject.toml` and `requirements.txt`.
+
+## Quickstart
+Run the tool against the provided sample data:
+
+```bash
+csv-clean --input examples/customers_small.csv --output-dir out
+```
+
+Outputs (all written to `--output-dir` unless `--dry-run` is used):
+
+- `clean.csv` – dataset with invalid emails removed and duplicates collapsed.
+- `duplicates.csv` – entries dropped due to exact email duplication, including `source_index` and `kept_index` columns.
+- `review.csv` – rows needing human review, including invalid emails and fuzzy matches with similarity scores.
+
+Pass `--dry-run` to skip writing files while still seeing the summary.
+
+## CLI options
+```
+Usage: csv-clean [OPTIONS]
+
+Options:
+  --input PATH                 Path to the input CSV file.  [required]
+  --output-dir PATH            Where to write the output CSV files.  [default: out]
+  --email-col TEXT             Name of the email column.  [default: email]
+  --name-col TEXT              Name column used for fuzzy matching.  [default: name]
+  --city-col TEXT              City column used for fuzzy matching.  [default: city]
+  --phone-col TEXT             Phone column (optional normalization).  [default: phone]
+  --threshold FLOAT RANGE      Fuzzy matching threshold between 0.6 and 0.95.  [default: 0.85]
+  --max-rows INTEGER           Optional safety limit for number of rows to read.
+  --separator TEXT             Field separator used in the CSV.  [default: ,]
+  --dry-run / --no-dry-run     Run the pipeline without writing any files.
+  -v, --verbose                Increase logging verbosity (use `-vv` for debug output).
+  --version                    Show the version and exit.
+  --help                       Show this message and exit.
+```
+
+### Custom column names
+```
+csv-clean \
+  --input data/raw_contacts.csv \
+  --email-col primaryEmail \
+  --name-col fullName \
+  --city-col hometown \
+  --phone-col workPhone
+```
+
+### Different separators
+```
+csv-clean --input data/contacts.tsv --separator "\t"
+```
+
+### Limiting rows for a quick preview
+```
+csv-clean --input huge.csv --max-rows 5000 --dry-run -v
+```
+
+## Sample data
+- `examples/customers_small.csv` – 15 records with deliberate exact duplicates, fuzzy matches, and invalid emails.
+- `examples/customers_medium.csv` – 422 synthetic rows with many near-duplicates to benchmark performance.
+
+## Development workflow
+Useful `make` targets:
+
+```bash
+make venv     # create .venv and install dependencies
+make test     # run pytest
+make format   # run ruff --fix and black on the codebase
+make run      # execute csv-clean against examples/customers_small.csv
+```
+
+## Performance notes
+- `csv-clean` loads the CSV with `pandas`. For very large files, use `--max-rows` to sample or split the input.
+- RapidFuzz comparisons are blocked by name initial and city to avoid quadratic blow-ups.
+- All processing happens in-memory; ensure you have enough RAM for the dataset size.
+
+## Privacy
+No data ever leaves your machine. The tool performs all work locally and does not contact external services.
+
+## Troubleshooting
+| Issue | Fix |
+| --- | --- |
+| **File not found / permission error** | Double-check the `--input` path and ensure you have read access. |
+| **Missing columns** | Use `--email-col`, `--name-col`, or `--city-col` to match your headers. The tool reports missing required columns and skips fuzzy matching if optional fields are absent. |
+| **Bad encoding (UnicodeDecodeError)** | Convert the CSV to UTF-8 (e.g., using spreadsheet software) before running `csv-clean`. |
+| **Strange characters or wrong separators** | Specify the separator with `--separator` (e.g., `;` or `\t`). |
+| **Large file memory pressure** | Use `--max-rows` for sampling or split the data into smaller chunks. |
+
+## Continuous integration
+GitHub Actions runs `pytest` on every push to ensure the pipeline remains healthy.

--- a/examples/customers_medium.csv
+++ b/examples/customers_medium.csv
@@ -1,0 +1,423 @@
+email,name,city,phone
+uma.diaz@demo.net,Uma Diaz,Austin,481-450-4657
+evelyn.xu@demo.net,Evelyn Xu,San Antonio,958-758-2424
+sara.nguyen@example.com,Sara Nguyen,Dallas,295-423-4811
+quinn.turner@demo.net,Quinn Turner,Austin,403-933-9928
+noah.hernandez@demo.net,Noah Hernandez,Brownsville,484-206-3615
+wendy.nguyen@sample.org,Wendy Nguyen,Garland,359-420-6514
+david.chen@example.com,David Chen,Amarillo,567-552-5333
+zane.brown@demo.net,Zane Brown,Brownsville,327-587-2291
+ramon.jones@sample.org,Ramon Jones,Mesquite,791-396-2139
+bob.vega@sample.org,Bob Vega,Plano,281-438-2654
+monica.ivanov@demo.net,Monica Ivanov,Brownsville,573-366-7065
+liam.garcia@demo.net,Liam Garcia,Lubbock,899-863-2169
+thomas.usman@demo.net,Thomas Usman,Fort Worth,946-450-3677
+olivia.martinez@demo.net,Olivia Martinez,Lubbock,904-770-4598
+victor.klein@example.com,Victor Klein,Dallas,232-523-7572
+irene.chen@demo.net,Irene Chen,Arlington,935-522-4483
+uma.patel@demo.net,Uma Patel,Amarillo,669-346-5339
+evelyn.hernandez@demo.net,Evelyn Hernandez,Pasadena,469-964-8019
+sara.martinez@example.com,Sara Martinez,Irving,341-721-9085
+carol.young@example.com,Carol Young,Dallas,356-842-3621
+zane.vega@demo.net,Zane Vega,Grand Prairie,265-594-7252
+thomas.owens@sample.org,Thomas Owens,Frisco,766-211-2876
+victor.reed@demo.net,Victor Reed,Lubbock,548-314-5808
+noah.foster@example.com,Noah Foster,Brownsville,939-936-5315
+quinn.young@demo.net,Quinn Young,Fort Worth,308-840-5889
+uma.quinn@example.com,Uma Quinn,Mesquite,356-582-3646
+ramon.young@example.com,Ramon Young,Frisco,813-531-9005
+alice.diaz@sample.org,Alice Diaz,Irving,445-259-4946
+sara.chen@demo.net,Sara Chen,Houston,697-270-9727
+yara.evans@demo.net,Yara Evans,El Paso,686-762-3705
+irene.quinn@sample.org,Irene Quinn,Mesquite,416-752-4295
+wendy.jones@demo.net,Wendy Jones,Amarillo,865-582-8177
+quinn.owens@example.com,Quinn Owens,San Antonio,430-265-6539
+alice.singh@example.com,Alice Singh,Pasadena,802-425-1117
+carol.white@example.com,Carol White,Dallas,269-232-6413
+carol.quinn@sample.org,Carol Quinn,Plano,885-697-4510
+ramon.evans@demo.net,Ramon Evans,Killeen,684-448-8749
+zane.nguyen@example.com,Zane Nguyen,Arlington,299-874-8062
+liam.nguyen@sample.org,Liam Nguyen,Grand Prairie,946-255-2612
+bob.martinez@example.com,Bob Martinez,Garland,454-396-4116
+ramon.owens@sample.org,Ramon Owens,El Paso,387-485-8579
+hector.chen@demo.net,Hector Chen,Brownsville,300-251-9856
+alice.chen@example.com,Alice Chen,Plano,616-697-8886
+grace.martinez@example.com,Grace Martinez,Dallas,588-202-7396
+irene.zhang@sample.org,Irene Zhang,Brownsville,633-913-8973
+evelyn.garcia@example.com,Evelyn Garcia,Corpus Christi,259-793-9883
+bob.xu@example.com,Bob Xu,Garland,251-798-8811
+quinn.quinn@example.com,Quinn Quinn,Fort Worth,720-282-4044
+carol.turner@demo.net,Carol Turner,Houston,440-613-2964
+sara.hernandez@demo.net,Sara Hernandez,Killeen,240-834-2343
+noah.vega@demo.net,Noah Vega,Killeen,735-523-5272
+grace.vega@example.com,Grace Vega,Garland,471-605-3144
+victor.usman@sample.org,Victor Usman,Corpus Christi,523-969-2188
+alice.owens@demo.net,Alice Owens,Mesquite,302-275-9808
+grace.quinn@example.com,Grace Quinn,Lubbock,557-270-5002
+liam.jones@sample.org,Liam Jones,Fort Worth,756-920-5956
+thomas.zhang@example.com,Thomas Zhang,Frisco,883-767-5905
+victor.diaz@sample.org,Victor Diaz,El Paso,318-309-3546
+irene.jones@example.com,Irene Jones,Mesquite,934-551-4335
+victor.usman@demo.net,Victor Usman,Lubbock,700-457-1832
+carol.usman@sample.org,Carol Usman,Grand Prairie,245-203-6464
+yara.evans@example.com,Yara Evans,Lubbock,959-652-8007
+ramon.anderson@example.com,Ramon Anderson,San Antonio,907-352-9938
+bob.lopez@demo.net,Bob Lopez,Killeen,351-640-3088
+bob.jones@example.com,Bob Jones,Irving,566-415-5088
+victor.diaz@demo.net,Victor Diaz,Irving,616-835-3532
+hector.foster@sample.org,Hector Foster,Fort Worth,225-383-6442
+zane.nguyen@sample.org,Zane Nguyen,Plano,363-918-2771
+monica.brown@example.com,Monica Brown,McKinney,404-671-6728
+jamal.zhang@example.com,Jamal Zhang,Plano,224-875-4164
+monica.klein@example.com,Monica Klein,Lubbock,991-485-6753
+uma.quinn@demo.net,Uma Quinn,Amarillo,749-539-1452
+david.ivanov@demo.net,David Ivanov,Fort Worth,471-239-2776
+thomas.nguyen@demo.net,Thomas Nguyen,Irving,521-646-9379
+david.martinez@example.com,David Martinez,Killeen,460-245-8144
+alice.quinn@demo.net,Alice Quinn,Pasadena,936-959-4228
+liam.nguyen@demo.net,Liam Nguyen,Houston,538-838-6143
+victor.diaz@demo.net,Victor Diaz,Corpus Christi,516-882-7691
+karen.martinez@demo.net,Karen Martinez,Corpus Christi,330-396-7888
+victor.martinez@demo.net,Victor Martinez,Fort Worth,782-508-7653
+ramon.anderson@sample.org,Ramon Anderson,Corpus Christi,415-640-6279
+olivia.owens@demo.net,Olivia Owens,Brownsville,418-723-8752
+zane.zhang@demo.net,Zane Zhang,Fort Worth,286-490-9445
+victor.usman@sample.org,Victor Usman,Mesquite,295-969-4848
+victor.jones@example.com,Victor Jones,Plano,350-225-1757
+hector.patel@example.com,Hector Patel,Mesquite,666-624-4185
+wendy.white@sample.org,Wendy White,Amarillo,609-449-3417
+uma.white@example.com,Uma White,Austin,997-635-4585
+frank.zhang@sample.org,Frank Zhang,Frisco,251-770-5082
+david.owens@sample.org,David Owens,El Paso,883-743-6198
+yara.owens@demo.net,Yara Owens,Mesquite,716-636-9976
+olivia.foster@sample.org,Olivia Foster,McKinney,465-969-5050
+uma.ivanov@sample.org,Uma Ivanov,Frisco,841-444-5499
+olivia.chen@example.com,Olivia Chen,Corpus Christi,478-543-6238
+ramon.chen@example.com,Ramon Chen,El Paso,436-592-3503
+wendy.garcia@sample.org,Wendy Garcia,Houston,617-538-9890
+olivia.nguyen@example.com,Olivia Nguyen,Dallas,630-598-1320
+yara.singh@sample.org,Yara Singh,Amarillo,206-560-5892
+yara.martinez@demo.net,Yara Martinez,Grand Prairie,965-952-9947
+zane.turner@sample.org,Zane Turner,Plano,424-479-8140
+priya.anderson@sample.org,Priya Anderson,Amarillo,884-895-7624
+xavier.foster@example.com,Xavier Foster,Brownsville,837-746-1441
+monica.singh@demo.net,Monica Singh,Killeen,227-285-8022
+evelyn.owens@example.com,Evelyn Owens,Fort Worth,466-588-6363
+grace.owens@sample.org,Grace Owens,Garland,979-588-5558
+yara.nguyen@example.com,Yara Nguyen,Lubbock,681-219-9837
+bob.lopez@demo.net,Bob Lopez,Plano,270-999-1659
+yara.anderson@example.com,Yara Anderson,Plano,220-836-3496
+hector.evans@demo.net,Hector Evans,McKinney,317-777-4571
+olivia.white@sample.org,Olivia White,Lubbock,371-820-2876
+yara.foster@example.com,Yara Foster,Corpus Christi,792-226-6111
+sara.vega@sample.org,Sara Vega,Amarillo,932-403-2245
+sara.white@example.com,Sara White,Plano,913-991-5941
+victor.turner@demo.net,Victor Turner,San Antonio,242-555-9728
+noah.vega@example.com,Noah Vega,Irving,718-863-6590
+alice.nguyen@example.com,Alice Nguyen,McKinney,643-570-8532
+wendy.evans@example.com,Wendy Evans,Grand Prairie,951-734-5425
+thomas.zhang@sample.org,Thomas Zhang,Pasadena,676-646-5397
+karen.hernandez@sample.org,Karen Hernandez,Houston,661-449-8613
+sara.turner@sample.org,Sara Turner,Amarillo,229-706-6325
+frank.patel@sample.org,Frank Patel,Arlington,464-548-5581
+thomas.white@demo.net,Thomas White,Lubbock,210-729-4130
+carol.hernandez@sample.org,Carol Hernandez,Grand Prairie,768-976-4937
+wendy.patel@sample.org,Wendy Patel,McKinney,217-295-5820
+hector.martinez@sample.org,Hector Martinez,Plano,879-795-7046
+priya.reed@sample.org,Priya Reed,Frisco,635-963-6419
+liam.white@sample.org,Liam White,Brownsville,513-457-4777
+david.xu@sample.org,David Xu,Arlington,322-960-9779
+yara.white@example.com,Yara White,Fort Worth,421-956-8933
+irene.xu@demo.net,Irene Xu,Killeen,811-489-2647
+grace.jones@sample.org,Grace Jones,Plano,383-509-1231
+wendy.reed@sample.org,Wendy Reed,El Paso,246-255-5786
+wendy.evans@example.com,Wendy Evans,McKinney,212-787-5658
+priya.patel@sample.org,Priya Patel,Brownsville,388-252-5136
+priya.diaz@sample.org,Priya Diaz,Houston,703-275-1878
+evelyn.evans@sample.org,Evelyn Evans,Killeen,287-454-2940
+ramon.young@demo.net,Ramon Young,Grand Prairie,810-833-4697
+yara.quinn@sample.org,Yara Quinn,Amarillo,653-504-8025
+jamal.singh@example.com,Jamal Singh,Mesquite,824-957-2625
+yara.garcia@sample.org,Yara Garcia,Arlington,876-283-3573
+hector.foster@example.com,Hector Foster,Pasadena,360-202-7693
+olivia.white@sample.org,Olivia White,Mesquite,498-233-4792
+jamal.white@demo.net,Jamal White,Corpus Christi,664-272-4824
+irene.zhang@demo.net,Irene Zhang,Killeen,402-635-2880
+ramon.hernandez@sample.org,Ramon Hernandez,El Paso,345-273-1977
+frank.zhang@demo.net,Frank Zhang,Corpus Christi,966-782-5728
+olivia.diaz@demo.net,Olivia Diaz,Brownsville,511-916-7594
+irene.quinn@sample.org,Irene Quinn,Pasadena,648-282-1653
+noah.xu@demo.net,Noah Xu,Garland,456-226-2496
+hector.vega@demo.net,Hector Vega,Killeen,221-983-5415
+sara.brown@sample.org,Sara Brown,Fort Worth,731-867-8245
+irene.foster@sample.org,Irene Foster,Killeen,850-703-2494
+priya.lopez@sample.org,Priya Lopez,Grand Prairie,528-886-2713
+frank.klein@demo.net,Frank Klein,Grand Prairie,707-495-7561
+yara.reed@sample.org,Yara Reed,Dallas,290-522-5135
+karen.diaz@demo.net,Karen Diaz,Amarillo,201-873-9889
+olivia.nguyen@example.com,Olivia Nguyen,Dallas,730-570-9167
+uma.owens@example.com,Uma Owens,Dallas,473-762-3146
+jamal.owens@example.com,Jamal Owens,McKinney,229-845-4920
+wendy.foster@demo.net,Wendy Foster,Corpus Christi,214-765-7684
+carol.hernandez@sample.org,Carol Hernandez,San Antonio,320-863-3522
+priya.white@demo.net,Priya White,Corpus Christi,922-479-7807
+priya.patel@sample.org,Priya Patel,Plano,764-348-7284
+grace.turner@demo.net,Grace Turner,Frisco,339-271-5526
+yara.zhang@sample.org,Yara Zhang,Grand Prairie,719-473-1042
+jamal.xu@demo.net,Jamal Xu,Corpus Christi,793-875-9022
+evelyn.owens@sample.org,Evelyn Owens,Pasadena,553-540-9903
+monica.owens@example.com,Monica Owens,Garland,914-444-7274
+hector.young@example.com,Hector Young,Grand Prairie,525-962-8749
+wendy.zhang@sample.org,Wendy Zhang,Amarillo,879-867-3492
+priya.brown@demo.net,Priya Brown,El Paso,804-539-2644
+olivia.diaz@sample.org,Olivia Diaz,Frisco,215-939-3361
+noah.usman@example.com,Noah Usman,El Paso,680-471-6546
+thomas.white@demo.net,Thomas White,Amarillo,282-536-9742
+monica.klein@demo.net,Monica Klein,McKinney,236-832-2121
+hector.usman@example.com,Hector Usman,Corpus Christi,964-292-8110
+david.young@sample.org,David Young,San Antonio,370-910-5906
+alice.brown@example.com,Alice Brown,Garland,500-567-7141
+noah.evans@demo.net,Noah Evans,Plano,621-779-3950
+frank.foster@demo.net,Frank Foster,Houston,591-834-4945
+priya.singh@example.com,Priya Singh,El Paso,672-853-5161
+olivia.ivanov@sample.org,Olivia Ivanov,Austin,494-893-9955
+frank.chen@sample.org,Frank Chen,Brownsville,801-506-7951
+wendy.ivanov@sample.org,Wendy Ivanov,Brownsville,403-593-8916
+david.hernandez@demo.net,David Hernandez,Amarillo,567-788-5847
+wendy.jones@demo.net,Wendy Jones,Austin,605-481-1132
+sara.vega@demo.net,Sara Vega,Dallas,963-708-5689
+yara.zhang@demo.net,Yara Zhang,Plano,560-424-4115
+thomas.ivanov@demo.net,Thomas Ivanov,El Paso,299-842-1645
+jamal.zhang@example.com,Jamal Zhang,Brownsville,793-573-3153
+carol.jones@demo.net,Carol Jones,Garland,625-379-4289
+evelyn.zhang@sample.org,Evelyn Zhang,Pasadena,743-713-5465
+frank.ivanov@sample.org,Frank Ivanov,McKinney,964-546-2886
+olivia.chen@example.com,Olivia Chen,El Paso,892-941-7511
+zane.reed@example.com,Zane Reed,Irving,604-214-5332
+ramon.diaz@sample.org,Ramon Diaz,Brownsville,888-966-5295
+sara.martinez@example.com,Sara Martinez,Irving,891-439-8724
+alice.turner@sample.org,Alice Turner,Pasadena,824-426-2035
+uma.owens@demo.net,Uma Owens,Corpus Christi,618-319-3290
+bob.brown@sample.org,Bob Brown,Corpus Christi,318-299-4846
+ramon.evans@sample.org,Ramon Evans,Amarillo,579-886-9850
+noah.singh@sample.org,Noah Singh,El Paso,870-301-9017
+thomas.nguyen@example.com,Thomas Nguyen,Lubbock,906-579-4559
+olivia.owens@sample.org,Olivia Owens,Plano,301-902-7018
+ramon.usman@example.com,Ramon Usman,Irving,607-482-4109
+david.owens@demo.net,David Owens,Houston,417-857-1349
+bob.zhang@example.com,Bob Zhang,Garland,328-778-4362
+carol.young@example.com,Carol Young,Pasadena,800-421-4817
+karen.young@demo.net,Karen Young,El Paso,202-483-3370
+evelyn.reed@example.com,Evelyn Reed,Lubbock,312-876-1422
+evelyn.anderson@example.com,Evelyn Anderson,Irving,802-531-1258
+frank.ivanov@example.com,Frank Ivanov,Dallas,959-631-9619
+david.xu@sample.org,David Xu,Houston,659-996-6931
+quinn.singh@sample.org,Quinn Singh,San Antonio,715-426-1710
+xavier.zhang@sample.org,Xavier Zhang,Frisco,669-858-1510
+bob.patel@sample.org,Bob Patel,Amarillo,902-310-9032
+wendy.owens@example.com,Wendy Owens,Houston,529-822-3430
+carol.evans@demo.net,Carol Evans,Lubbock,848-799-9984
+wendy.klein@demo.net,Wendy Klein,Amarillo,743-501-8433
+quinn.turner@example.com,Quinn Turner,Grand Prairie,918-317-4522
+noah.owens@sample.org,Noah Owens,Plano,547-664-7532
+noah.xu@sample.org,Noah Xu,San Antonio,637-520-5176
+liam.evans@example.com,Liam Evans,McKinney,293-287-2527
+noah.diaz@example.com,Noah Diaz,Irving,769-261-6400
+victor.diaz@sample.org,Victor Diaz,Grand Prairie,881-968-7929
+xavier.brown@demo.net,Xavier Brown,Corpus Christi,519-560-2697
+sara.quinn@example.com,Sara Quinn,Arlington,872-693-4674
+david.lopez@sample.org,David Lopez,Pasadena,317-980-5564
+sara.hernandez@demo.net,Sara Hernandez,Grand Prairie,985-836-1430
+thomas.vega@example.com,Thomas Vega,Lubbock,384-479-6062
+karen.lopez@example.com,Karen Lopez,Austin,346-779-7566
+carol.evans@example.com,Carol Evans,Austin,964-743-4524
+monica.nguyen@sample.org,Monica Nguyen,Brownsville,361-578-6105
+xavier.klein@demo.net,Xavier Klein,Killeen,286-253-3549
+frank.young@example.com,Frank Young,Mesquite,890-283-5458
+olivia.vega@sample.org,Olivia Vega,Grand Prairie,821-652-7785
+irene.garcia@example.com,Irene Garcia,Frisco,553-640-2816
+jamal.vega@sample.org,Jamal Vega,Killeen,739-883-6053
+bob.hernandez@demo.net,Bob Hernandez,Amarillo,256-207-4349
+jamal.garcia@sample.org,Jamal Garcia,El Paso,496-535-2965
+alice.patel@example.com,Alice Patel,Grand Prairie,332-589-9725
+wendy.hernandez@demo.net,Wendy Hernandez,Frisco,884-562-2180
+monica.xu@sample.org,Monica Xu,Dallas,219-670-2275
+karen.singh@demo.net,Karen Singh,Grand Prairie,614-926-7843
+jamal.diaz@example.com,Jamal Diaz,Amarillo,532-375-8538
+wendy.lopez@sample.org,Wendy Lopez,Houston,308-449-8138
+sara.martinez@example.com,Sara Martinez,Frisco,605-517-6562
+hector.klein@example.com,Hector Klein,Fort Worth,722-848-2868
+quinn.quinn@sample.org,Quinn Quinn,Arlington,559-944-3419
+hector.diaz@sample.org,Hector Diaz,El Paso,402-377-3504
+yara.young@example.com,Yara Young,Houston,991-843-9095
+olivia.young@demo.net,Olivia Young,Killeen,659-897-6295
+uma.klein@sample.org,Uma Klein,El Paso,269-680-8245
+uma.jones@demo.net,Uma Jones,Lubbock,257-560-9312
+carol.jones@sample.org,Carol Jones,Brownsville,238-258-7041
+jamal.chen@demo.net,Jamal Chen,Houston,808-719-7299
+olivia.singh@demo.net,Olivia Singh,Pasadena,242-660-4084
+karen.turner@demo.net,Karen Turner,McKinney,354-263-8381
+david.zhang@demo.net,David Zhang,Garland,286-716-3827
+bob.hernandez@sample.org,Bob Hernandez,Brownsville,736-735-3600
+liam.lopez@sample.org,Liam Lopez,Corpus Christi,618-993-6543
+victor.turner@demo.net,Victor Turner,Dallas,862-542-2079
+karen.diaz@demo.net,Karen Diaz,Pasadena,595-490-5128
+xavier.vega@example.com,Xavier Vega,Mesquite,541-283-3317
+liam.jones@example.com,Liam Jones,Amarillo,809-925-2388
+jamal.reed@demo.net,Jamal Reed,Amarillo,536-330-9624
+carol.usman@demo.net,Carol Usman,Grand Prairie,570-218-6940
+jamal.foster@sample.org,Jamal Foster,Arlington,984-697-4145
+hector.evans@example.com,Hector Evans,El Paso,502-303-9317
+yara.reed@example.com,Yara Reed,Frisco,877-544-3147
+thomas.martinez@example.com,Thomas Martinez,El Paso,385-909-3712
+xavier.owens@sample.org,Xavier Owens,Dallas,573-892-4891
+olivia.turner@demo.net,Olivia Turner,Corpus Christi,659-439-9749
+hector.jones@example.com,Hector Jones,McKinney,576-894-8218
+olivia.young@sample.org,Olivia Young,Corpus Christi,714-740-7859
+frank.garcia@example.com,Frank Garcia,Mesquite,456-253-8873
+liam.reed@demo.net,Liam Reed,San Antonio,728-327-5670
+carol.young@sample.org,Carol Young,Fort Worth,660-725-3414
+noah.chen@sample.org,Noah Chen,Plano,557-227-7797
+bob.martinez@sample.org,Bob Martinez,Frisco,441-595-2337
+liam.hernandez@sample.org,Liam Hernandez,Austin,301-931-6493
+zane.evans@example.com,Zane Evans,El Paso,493-683-3273
+yara.white@sample.org,Yara White,McKinney,830-205-2298
+alice.ivanov@example.com,Alice Ivanov,Arlington,761-944-9647
+noah.diaz@example.com,Noah Diaz,Corpus Christi,508-324-1782
+hector.nguyen@sample.org,Hector Nguyen,Mesquite,264-313-9189
+thomas.reed@demo.net,Thomas Reed,Austin,727-788-4963
+wendy.evans@sample.org,Wendy Evans,Corpus Christi,201-829-6780
+hector.singh@example.com,Hector Singh,Grand Prairie,880-884-2402
+quinn.lopez@demo.net,Quinn Lopez,Houston,757-719-9316
+ramon.anderson@sample.org,Ramon Anderson,Amarillo,244-850-7338
+liam.ivanov@sample.org,Liam Ivanov,Austin,269-553-4950
+xavier.vega@demo.net,Xavier Vega,San Antonio,952-974-6447
+evelyn.brown@demo.net,Evelyn Brown,Irving,546-858-3868
+yara.vega@demo.net,Yara Vega,Brownsville,690-846-3986
+zane.evans@demo.net,Zane Evans,Houston,994-668-1605
+jamal.garcia@example.com,Jamal Garcia,Dallas,242-523-6080
+quinn.martinez@sample.org,Quinn Martinez,Pasadena,459-237-4131
+jamal.lopez@demo.net,Jamal Lopez,Dallas,539-479-3039
+zane.lopez@sample.org,Zane Lopez,Grand Prairie,961-650-7334
+karen.foster@demo.net,Karen Foster,McKinney,709-576-9507
+irene.zhang@demo.net,Irene Zhang,Houston,634-280-8055
+thomas.foster@sample.org,Thomas Foster,Pasadena,528-305-2311
+karen.vega@sample.org,Karen Vega,Corpus Christi,656-817-7981
+frank.white@sample.org,Frank White,Brownsville,657-243-6776
+thomas.nguyen@demo.net,Thomas Nguyen,Lubbock,258-276-7655
+liam.quinn@example.com,Liam Quinn,Fort Worth,346-822-8179
+bob.evans@example.com,Bob Evans,Houston,997-860-7001
+liam.martinez@example.com,Liam Martinez,Killeen,819-357-8371
+liam.lopez@example.com,Liam Lopez,Brownsville,787-340-9674
+liam.martinez@demo.net,Liam Martinez,Garland,485-455-2858
+alice.xu@sample.org,Alice Xu,Fort Worth,730-596-2929
+irene.young@demo.net,Irene Young,Lubbock,656-419-5678
+wendy.patel@example.com,Wendy Patel,Arlington,338-275-8406
+frank.white@example.com,Frank White,Brownsville,898-527-6692
+wendy.chen@demo.net,Wendy Chen,Pasadena,497-507-3580
+wendy.white@sample.org,Wendy White,Fort Worth,720-429-2988
+grace.zhang@example.com,Grace Zhang,El Paso,705-226-6912
+ramon.singh@sample.org,Ramon Singh,Irving,764-332-2412
+carol.jones@demo.net,Carol Jones,Amarillo,936-690-9612
+noah.young@demo.net,Noah Young,Grand Prairie,275-328-6194
+uma.chen@sample.org,Uma Chen,Brownsville,896-729-6644
+evelyn.young@demo.net,Evelyn Young,Pasadena,801-386-3114
+noah.quinn@example.com,Noah Quinn,Dallas,730-356-5982
+frank.foster@demo.net,Frank Foster,Garland,430-554-9501
+jamal.chen@example.com,Jamal Chen,Lubbock,850-764-5496
+evelyn.usman@demo.net,Evelyn Usman,Corpus Christi,746-295-9234
+uma.foster@demo.net,Uma Foster,Killeen,357-375-6531
+sara.brown@example.com,Sara Brown,Austin,246-856-5336
+uma.garcia@sample.org,Uma Garcia,Killeen,832-854-1496
+priya.usman@sample.org,Priya Usman,Pasadena,857-509-8912
+hector.zhang@sample.org,Hector Zhang,Amarillo,664-274-1981
+frank.owens@sample.org,Frank Owens,Grand Prairie,675-408-6573
+thomas.evans@demo.net,Thomas Evans,Garland,526-951-6658
+monica.evans@demo.net,Monica Evans,Irving,775-308-6228
+hector.owens@sample.org,Hector Owens,San Antonio,660-453-3308
+david.brown@sample.org,David Brown,Corpus Christi,830-628-5067
+frank.klein@demo.net,Frank Klein,Killeen,520-394-3610
+priya.quinn@sample.org,Priya Quinn,Brownsville,515-709-1379
+carol.martinez@sample.org,Carol Martinez,Frisco,446-420-6781
+bob.brown@sample.org,Bob Brown,Corpus Christi,811-869-8710
+jamal.reed@example.com,Jamal Reed,Austin,641-337-5333
+xavier.lopez@sample.org,Xavier Lopez,Amarillo,246-610-1838
+sara.reed@sample.org,Sara Reed,Arlington,766-495-2204
+monica.quinn@demo.net,Monica Quinn,Brownsville,486-838-2946
+evelyn.diaz@sample.org,Evelyn Diaz,Amarillo,547-771-6990
+yara.evans@demo.net,Yara Evans,Arlington,721-611-9193
+bob.brown@example.com,Bob Brown,Dallas,930-541-8761
+quinn.owens@demo.net,Quinn Owens,El Paso,727-343-6373
+thomas.klein@sample.org,Thomas Klein,Fort Worth,831-957-5902
+sara.klein@demo.net,Sara Klein,Frisco,745-701-5911
+priya.anderson@sample.org,Priya Anderson,Irving,889-312-7824
+sara.jones@demo.net,Sara Jones,Austin,685-471-4728
+xavier.brown@sample.org,Xavier Brown,Killeen,374-736-7229
+evelyn.vega@example.com,Evelyn Vega,Plano,786-917-2800
+grace.anderson@sample.org,Grace Anderson,Brownsville,628-355-7765
+wendy.garcia@demo.net,Wendy Garcia,Grand Prairie,993-826-8726
+xavier.xu@demo.net,Xavier Xu,Dallas,341-731-4397
+ramon.klein@demo.net,Ramon Klein,McKinney,585-521-3837
+olivia.reed@demo.net,Olivia Reed,Garland,562-892-5331
+uma.diaz@demo.net,Uma Diaz,Austin,481-450-4657
+evelyn.xu@demo.net,Evelyn Xu,San Antonio,958-758-2424
+sara.nguyen@example.com,Sara Nguyen,Dallas,295-423-4811
+quinn.turner@demo.net,Quinn Turner,Austin,403-933-9928
+noah.hernandez@demo.net,Noah Hernandez,Brownsville,484-206-3615
+wendy.nguyen@sample.org,Wendy Nguyen,Garland,359-420-6514
+david.chen@example.com,David Chen,Amarillo,567-552-5333
+zane.brown@demo.net,Zane Brown,Brownsville,327-587-2291
+ramon.jones@sample.org,Ramon Jones,Mesquite,791-396-2139
+bob.vega@sample.org,Bob Vega,Plano,281-438-2654
+monica.ivanov@demo.net,Monica Ivanov,Brownsville,573-366-7065
+liam.garcia@demo.net,Liam Garcia,Lubbock,899-863-2169
+thomas.usman@demo.net,Thomas Usman,Fort Worth,946-450-3677
+olivia.martinez@demo.net,Olivia Martinez,Lubbock,904-770-4598
+victor.klein@example.com,Victor Klein,Dallas,232-523-7572
+irene.chen@demo.net,Irene Chen,Arlington,935-522-4483
+uma.patel@demo.net,Uma Patel,Amarillo,669-346-5339
+evelyn.hernandez@demo.net,Evelyn Hernandez,Pasadena,469-964-8019
+sara.martinez@example.com,Sara Martinez,Irving,341-721-9085
+carol.young@example.com,Carol Young,Dallas,356-842-3621
+zane.vega+promo@demo.net,Zane Vega,Grand Prairie,265-594-7252
+thomas.owens+promo@sample.org,Thomas Owens,Frisco,766-211-2876
+victor.reed+promo@demo.net,Victor Reed,Lubbock,548-314-5808
+noah.foster+promo@example.com,Noah Foster,Brownsville,939-936-5315
+quinn.young+promo@demo.net,Quinn Young,Fort Worth,308-840-5889
+uma.quinn+promo@example.com,Uma Quinn,Mesquite,356-582-3646
+ramon.young+promo@example.com,Ramon Young,Frisco,813-531-9005
+alice.diaz+promo@sample.org,Alice Diaz,Irving,445-259-4946
+sara.chen+promo@demo.net,Sara Chen,Houston,697-270-9727
+yara.evans+promo@demo.net,Yara Evans,El Paso,686-762-3705
+irene.quinn+promo@sample.org,Irene Quinn,Mesquite,416-752-4295
+wendy.jones+promo@demo.net,Wendy Jones,Amarillo,865-582-8177
+quinn.owens+promo@example.com,Quinn Owens,San Antonio,430-265-6539
+alice.singh+promo@example.com,Alice Singh,Pasadena,802-425-1117
+carol.white+promo@example.com,Carol White,Dallas,269-232-6413
+carol.quinn+promo@sample.org,Carol Quinn,Plano,885-697-4510
+ramon.evans+promo@demo.net,Ramon Evans,Killeen,684-448-8749
+zane.nguyen+promo@example.com,Zane Nguyen,Arlington,299-874-8062
+liam.nguyen+promo@sample.org,Liam Nguyen,Grand Prairie,946-255-2612
+bob.martinez+promo@example.com,Bob Martinez,Garland,454-396-4116
+ramon.owens@sample.org,Ramon  Owens,El Paso,387-485-8579
+hector.chen@demo.net,Hector  Chen,Brownsville,300-251-9856
+alice.chen@example.com,Alice  Chen,Plano,616-697-8886
+grace.martinez@example.com,Grace  Martinez,Dallas,588-202-7396
+irene.zhang@sample.org,Irene  Zhang,Brownsville,633-913-8973
+evelyn.garcia@example.com,Evelyn  Garcia,Corpus Christi,259-793-9883
+bob.xu@example.com,Bob  Xu,Garland,251-798-8811
+quinn.quinn@example.com,Quinn  Quinn,Fort Worth,720-282-4044
+carol.turner@demo.net,Carol  Turner,Houston,440-613-2964
+sara.hernandez@demo.net,Sara  Hernandez,Killeen,240-834-2343
+noah.vega@demo.net,Noah  Vega,Killeen,735-523-5272
+grace.vega@example.com,Grace  Vega,Garland,471-605-3144
+victor.usman@sample.org,Victor  Usman,Corpus Christi,523-969-2188
+alice.owens@demo.net,Alice  Owens,Mesquite,302-275-9808
+grace.quinn@example.com,Grace  Quinn,Lubbock,557-270-5002
+liam.jones@sample.org,Liam  Jones,Fort Worth,756-920-5956
+thomas.zhang@example.com,Thomas  Zhang,Frisco,883-767-5905
+victor.diaz@sample.org,Victor  Diaz,El Paso,318-309-3546
+irene.jones@example.com,Irene  Jones,Mesquite,934-551-4335
+victor.usman@demo.net,Victor  Usman,Lubbock,700-457-1832
+invalid-email,Misty Harbor,Austin,512-555-7777
+,Ghost Entry,Dallas,214-555-8888

--- a/examples/customers_small.csv
+++ b/examples/customers_small.csv
@@ -1,0 +1,16 @@
+email,name,city,phone
+maria.garcia@example.com,Maria Garcia,Austin,512-555-0101
+john.doe@example.com,John Doe,Dallas,214-555-0110
+john.doe+promo@example.com,John Doe,Houston,713-555-0220
+sofia.lee@example.com,Sofia Lee,Austin,512-555-0134
+ajenkins@example.com,Alex Jenkins,San Antonio,210-555-0188
+cynthia.chan@example.com,Cynthia Chan,Dallas,214-555-0440
+maria.garcia@example.com,Maria Garcia,Austin,512-555-0101
+emily.santos@example.com,Emily Santos,Fort Worth,682-555-0300
+rachel.roe@example.org,Rachel Roe,Plano,469-555-0711
+rachelroe@example.org,Rachel Roe,Plano,469-555-0711
+invalid-email,Ramon Ortiz,El Paso,915-555-0505
+paul.nguyen@example.com,Paul Nguyen,San Jose,408-555-0606
+sierra.james@example.com,Sierra James,Austin,512-555-0199
+mike.thomas@example.net,Mike Thomas,Houston,713-555-0999
+lucy-b@example.com,Lucy Brown,San Diego,619-555-0420

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,56 @@
+[build-system]
+requires = ["hatchling>=1.18"]
+build-backend = "hatchling.build"
+
+[project]
+name = "csv-clean"
+version = "0.1.0"
+description = "CSV deduplication and fuzzy matching CLI"
+readme = "README.md"
+authors = [{ name = "csv-clean maintainers" }]
+license = { text = "MIT" }
+requires-python = ">=3.11"
+dependencies = [
+    "pandas>=2.1,<3",
+    "rapidfuzz>=3.0,<4",
+    "typer>=0.9,<0.10",
+    "rich>=13,<14",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.4,<8",
+    "black>=24.1,<25",
+    "ruff>=0.3,<0.5",
+]
+
+[project.scripts]
+csv-clean = "csv_clean.cli:entrypoint"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/csv_clean"]
+
+[tool.pytest.ini_options]
+addopts = "-ra"
+pythonpath = ["src"]
+
+[tool.black]
+line-length = 88
+skip-string-normalization = false
+target-version = ["py311"]
+
+[tool.ruff]
+line-length = 88
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "F", "B", "I"]
+ignore = []
+
+[tool.ruff.lint.per-file-ignores]
+"src/csv_clean/cli.py" = ["B008"]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+line-ending = "auto"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+pandas==2.2.2
+rapidfuzz==3.6.1
+typer==0.9.0
+rich==13.7.1
+pytest==7.4.4
+black==24.4.2
+ruff==0.4.5

--- a/src/csv_clean/__init__.py
+++ b/src/csv_clean/__init__.py
@@ -1,0 +1,7 @@
+"""Top-level package for csv-clean CLI."""
+
+from __future__ import annotations
+
+__all__ = ["__version__"]
+
+__version__ = "0.1.0"

--- a/src/csv_clean/cli.py
+++ b/src/csv_clean/cli.py
@@ -1,0 +1,232 @@
+"""Command line interface for the csv-clean tool."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Optional
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from . import __version__
+from .processing import (
+    CSVRuntimeError,
+    CSVValidationError,
+    ProcessingConfig,
+    apply_normalization,
+    find_potential_duplicates,
+    prepare_output_frames,
+    read_input_csv,
+    remove_exact_duplicates,
+    validate_columns,
+)
+
+console = Console()
+app = typer.Typer(add_completion=False, no_args_is_help=True)
+
+
+def _print_verbose(message: str, *, verbosity: int, level: int = 1) -> None:
+    """Print helper that respects the verbosity level."""
+
+    if verbosity >= level:
+        console.print(message)
+
+
+def run_pipeline(
+    *,
+    input_path: Path,
+    output_dir: Path,
+    email_col: str,
+    name_col: str,
+    city_col: str,
+    phone_col: str,
+    threshold: float,
+    max_rows: Optional[int],
+    separator: str,
+    dry_run: bool,
+    verbose: int,
+) -> None:
+    """Execute the deduplication workflow."""
+
+    start_time = time.perf_counter()
+
+    if not input_path.exists():
+        console.print(f"[red]Input file not found:[/red] {input_path}")
+        raise typer.Exit(code=2)
+
+    _print_verbose("Reading input CSV...", verbosity=verbose)
+
+    try:
+        df = read_input_csv(input_path, separator=separator, max_rows=max_rows)
+    except FileNotFoundError as exc:
+        console.print(f"[red]Input file not found:[/red] {input_path}")
+        raise typer.Exit(code=2) from exc
+    except CSVValidationError as exc:
+        console.print(f"[red]Validation error:[/red] {exc}")
+        raise typer.Exit(code=2) from exc
+    except Exception as exc:  # pragma: no cover - defensive guard
+        console.print(f"[red]Unexpected error while reading CSV:[/red] {exc}")
+        raise typer.Exit(code=3) from exc
+
+    config = ProcessingConfig(
+        email_col=email_col,
+        name_col=name_col,
+        city_col=city_col,
+        phone_col=phone_col,
+        original_columns=list(df.columns),
+    )
+
+    try:
+        validate_columns(df, config)
+    except CSVValidationError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(code=2) from exc
+
+    if not config.has_name():
+        name_warning = (
+            f"[yellow]Column '{name_col}' missing; name fuzzy match skipped.[/yellow]"
+        )
+        console.print(name_warning)
+    if not config.has_city():
+        city_warning = (
+            f"[yellow]Column '{city_col}' missing; city fuzzy match skipped.[/yellow]"
+        )
+        console.print(city_warning)
+
+    _print_verbose("Normalizing records...", verbosity=verbose)
+
+    try:
+        normalized_df, review_records = apply_normalization(df, config)
+    except CSVRuntimeError as exc:  # pragma: no cover - defensive
+        console.print(f"[red]Runtime error:[/red] {exc}")
+        raise typer.Exit(code=3) from exc
+
+    invalid_count = len(review_records)
+    if invalid_count:
+        email_warning = (
+            f"[yellow]{invalid_count} row(s) flagged for email review.[/yellow]"
+        )
+        console.print(email_warning)
+
+    _print_verbose("Removing exact duplicates...", verbosity=verbose)
+    clean_df, duplicates_df = remove_exact_duplicates(normalized_df)
+
+    duplicate_summary = (
+        f"[green]{len(clean_df)}[/green] clean row(s); "
+        f"[cyan]{len(duplicates_df)}[/cyan] exact duplicate(s) removed."
+    )
+    console.print(duplicate_summary)
+
+    if config.has_name() and config.has_city():
+        _print_verbose("Running fuzzy matching...", verbosity=verbose)
+        fuzzy_records = find_potential_duplicates(clean_df, config, threshold=threshold)
+        review_records.extend(fuzzy_records)
+        fuzzy_summary = (
+            f"[magenta]{len(fuzzy_records)}[/magenta] potential duplicate pair(s) "
+            "added for review."
+        )
+        console.print(fuzzy_summary)
+    else:
+        console.print(
+            "[yellow]Fuzzy matching skipped; missing name or city column.[/yellow]"
+        )
+
+    clean_output, duplicates_output, review_output = prepare_output_frames(
+        clean_df, duplicates_df, review_records, config
+    )
+
+    if dry_run:
+        console.print("[cyan]Dry-run enabled; no files were written.[/cyan]")
+    else:
+        output_dir.mkdir(parents=True, exist_ok=True)
+        clean_output.to_csv(output_dir / "clean.csv", index=False, sep=separator)
+        duplicates_output.to_csv(
+            output_dir / "duplicates.csv", index=False, sep=separator
+        )
+        review_output.to_csv(output_dir / "review.csv", index=False, sep=separator)
+        console.print(f"[green]Results written to {output_dir.resolve()}[/green]")
+
+    elapsed = time.perf_counter() - start_time
+    summary = Table(title="Summary", show_header=True, header_style="bold blue")
+    summary.add_column("File")
+    summary.add_column("Rows", justify="right")
+    summary.add_row("clean.csv", str(len(clean_output)))
+    summary.add_row("duplicates.csv", str(len(duplicates_output)))
+    summary.add_row("review.csv", str(len(review_output)))
+    console.print(summary)
+    console.print(f"Completed in {elapsed:0.2f} seconds.")
+
+
+@app.callback(invoke_without_command=True)
+def main(  # noqa: B008
+    ctx: typer.Context,
+    input: Path = typer.Option(..., "--input", help="Path to the input CSV file."),
+    output_dir: Path = typer.Option(
+        Path("out"), "--output-dir", help="Where to write the output CSV files."
+    ),
+    email_col: str = typer.Option("email", help="Name of the email column."),
+    name_col: str = typer.Option("name", help="Name column used for fuzzy matching."),
+    city_col: str = typer.Option("city", help="City column used for fuzzy matching."),
+    phone_col: str = typer.Option(
+        "phone",
+        help="Phone column (optional normalization).",
+    ),
+    threshold: float = typer.Option(
+        0.85,
+        min=0.6,
+        max=0.95,
+        help="Fuzzy matching threshold between 0.6 and 0.95.",
+    ),
+    max_rows: Optional[int] = typer.Option(
+        None, help="Optional safety limit for number of rows to read."
+    ),
+    separator: str = typer.Option(",", help="Field separator used in the CSV."),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run/--no-dry-run",
+        help="Run the pipeline without writing any files.",
+    ),
+    verbose: int = typer.Option(
+        0, "--verbose", "-v", count=True, help="Increase logging verbosity."
+    ),
+    version: bool = typer.Option(
+        False,
+        "--version",
+        is_eager=True,
+        help="Show the version and exit.",
+    ),
+) -> None:
+    """Typer callback that dispatches to the processing pipeline."""
+
+    if version:
+        console.print(f"csv-clean version {__version__}")
+        raise typer.Exit()
+
+    if ctx.invoked_subcommand is not None:
+        return
+
+    run_pipeline(
+        input_path=input,
+        output_dir=output_dir,
+        email_col=email_col,
+        name_col=name_col,
+        city_col=city_col,
+        phone_col=phone_col,
+        threshold=threshold,
+        max_rows=max_rows,
+        separator=separator,
+        dry_run=dry_run,
+        verbose=verbose,
+    )
+
+
+def entrypoint() -> None:
+    """Entrypoint for console script."""
+
+    app()
+
+
+if __name__ == "__main__":  # pragma: no cover - script entry
+    entrypoint()

--- a/src/csv_clean/processing.py
+++ b/src/csv_clean/processing.py
@@ -1,0 +1,358 @@
+"""Core processing utilities for the csv-clean CLI."""
+
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+from dataclasses import dataclass
+from itertools import combinations
+from pathlib import Path
+from typing import Any, Dict, List, Sequence, Tuple
+
+import pandas as pd
+from rapidfuzz import fuzz
+
+EMAIL_REGEX = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+
+
+class CSVValidationError(Exception):
+    """Raised when the input data fails upfront validation."""
+
+
+class CSVRuntimeError(Exception):
+    """Raised when an unexpected runtime problem occurs."""
+
+
+@dataclass(slots=True)
+class ProcessingConfig:
+    """Configuration for column names and contextual metadata."""
+
+    email_col: str
+    name_col: str
+    city_col: str
+    phone_col: str
+    original_columns: List[str]
+
+    def has_name(self) -> bool:
+        return self.name_col in self.original_columns
+
+    def has_city(self) -> bool:
+        return self.city_col in self.original_columns
+
+    def has_phone(self) -> bool:
+        return self.phone_col in self.original_columns
+
+
+def read_input_csv(
+    path: Path,
+    separator: str = ",",
+    max_rows: int | None = None,
+) -> pd.DataFrame:
+    """Read a CSV file into a DataFrame with sensible defaults."""
+
+    try:
+        df = pd.read_csv(
+            path,
+            sep=separator,
+            dtype=str,
+            keep_default_na=False,
+            nrows=max_rows,
+        )
+    except FileNotFoundError:  # pragma: no cover - handled by CLI
+        raise
+    except pd.errors.EmptyDataError as exc:
+        raise CSVValidationError("The provided CSV file is empty.") from exc
+    except UnicodeDecodeError as exc:
+        message = (
+            "Unable to decode the file using UTF-8. Check encoding or provide "
+            "a different file."
+        )
+        raise CSVValidationError(message) from exc
+
+    if df.empty:
+        raise CSVValidationError("The provided CSV file contains no rows.")
+
+    # Strip whitespace from column headers to avoid subtle mismatches.
+    df.rename(columns={col: col.strip() for col in df.columns}, inplace=True)
+    df.reset_index(drop=True, inplace=True)
+    return df
+
+
+def validate_columns(df: pd.DataFrame, config: ProcessingConfig) -> None:
+    """Ensure required columns exist before processing."""
+
+    missing: List[str] = []
+    if config.email_col not in df.columns:
+        missing.append(config.email_col)
+
+    if missing:
+        missing_message = "Missing required column(s): " + ", ".join(
+            sorted(set(missing))
+        )
+        raise CSVValidationError(missing_message)
+
+
+def _normalize_email(value: Any) -> Tuple[str | None, str | None]:
+    """Normalize email addresses and return potential issues."""
+
+    if value is None:
+        return None, "missing_email"
+
+    text = str(value).strip()
+    if not text:
+        return None, "missing_email"
+
+    lowered = text.lower()
+    if not EMAIL_REGEX.match(lowered):
+        return None, "invalid_email"
+
+    return lowered, None
+
+
+def _normalize_phone(value: Any) -> str:
+    """Keep only digits from phone numbers."""
+
+    if value is None:
+        return ""
+    return "".join(ch for ch in str(value) if ch.isdigit())
+
+
+def _normalize_name(value: Any) -> str:
+    """Normalize a name for matching purposes."""
+
+    if value is None:
+        return ""
+    text = str(value).strip()
+    if not text:
+        return ""
+    collapsed = re.sub(r"\s+", " ", text)
+    return collapsed.title()
+
+
+def _normalize_city(value: Any) -> str:
+    """Normalize a city for matching purposes."""
+
+    if value is None:
+        return ""
+    text = str(value).strip()
+    if not text:
+        return ""
+    collapsed = re.sub(r"\s+", " ", text)
+    return collapsed.title()
+
+
+def _clean_value(value: Any) -> str:
+    """Convert values to clean strings for CSV export."""
+
+    if value is None:
+        return ""
+    if isinstance(value, float) and pd.isna(value):
+        return ""
+    if isinstance(value, str):
+        return value
+    if pd.isna(value):  # type: ignore[arg-type]
+        return ""
+    return str(value)
+
+
+def _build_review_record(
+    row: pd.Series,
+    config: ProcessingConfig,
+    *,
+    reason: str,
+    note: str = "",
+    other_row: pd.Series | None = None,
+    score: float | None = None,
+) -> Dict[str, Any]:
+    """Create a dictionary capturing review information for CSV export."""
+
+    record: Dict[str, Any] = {
+        "reason": reason,
+        "score": round(score, 4) if score is not None else "",
+        "row_index": int(row["_original_index"]),
+        "note": note,
+    }
+    if other_row is not None:
+        record["other_index"] = int(other_row["_original_index"])
+    else:
+        record["other_index"] = ""
+
+    for col in config.original_columns:
+        row_key = f"row_{col}"
+        other_key = f"other_{col}"
+        record[row_key] = _clean_value(row.get(col))
+        other_value = other_row.get(col) if other_row is not None else ""
+        record[other_key] = _clean_value(other_value)
+
+    return record
+
+
+def apply_normalization(
+    df: pd.DataFrame, config: ProcessingConfig
+) -> Tuple[pd.DataFrame, List[Dict[str, Any]]]:
+    """Normalize key columns and return valid rows plus review records."""
+
+    working = df.copy()
+    working.reset_index(drop=True, inplace=True)
+    working["_original_index"] = working.index
+
+    # Normalize email values.
+    email_results = working[config.email_col].apply(_normalize_email)
+    working["_normalized_email"] = [result[0] for result in email_results]
+    working["_email_issue"] = [result[1] for result in email_results]
+
+    # Normalize optional fields if present.
+    if config.has_phone():
+        working["_normalized_phone"] = working[config.phone_col].apply(_normalize_phone)
+    else:
+        working["_normalized_phone"] = ""
+
+    if config.has_name():
+        working["_normalized_name"] = working[config.name_col].apply(_normalize_name)
+    else:
+        working["_normalized_name"] = ""
+
+    if config.has_city():
+        working["_normalized_city"] = working[config.city_col].apply(_normalize_city)
+    else:
+        working["_normalized_city"] = ""
+
+    name_component = working["_normalized_name"].str.strip()
+    city_component = working["_normalized_city"].str.strip()
+    combined_key = name_component + " " + city_component
+    working["_match_key"] = combined_key.str.strip().fillna("")
+
+    review_records: List[Dict[str, Any]] = []
+    issue_mask = working["_email_issue"].notna()
+    if issue_mask.any():
+        issue_rows = working.loc[issue_mask]
+        for _, row in issue_rows.iterrows():
+            reason = str(row["_email_issue"])
+            if reason == "missing_email":
+                note = "Missing or empty email address"
+            else:
+                note = "Invalid email format"
+            review_records.append(
+                _build_review_record(row, config, reason=reason, note=note)
+            )
+        working = working.loc[~issue_mask].copy()
+
+    return working, review_records
+
+
+def remove_exact_duplicates(
+    df: pd.DataFrame,
+) -> Tuple[pd.DataFrame, pd.DataFrame]:
+    """Split exact email duplicates from the clean dataset."""
+
+    if "_normalized_email" not in df.columns:
+        raise CSVRuntimeError("Normalized email column missing from DataFrame.")
+
+    duplicated_mask = df["_normalized_email"].duplicated(keep="first")
+    duplicates = df.loc[duplicated_mask].copy()
+    clean = df.loc[~duplicated_mask].copy()
+
+    if not duplicates.empty:
+        first_occurrence = clean.drop_duplicates(
+            subset="_normalized_email", keep="first"
+        ).set_index("_normalized_email")["_original_index"]
+        duplicates["source_index"] = duplicates["_original_index"].astype(int)
+        duplicates["kept_index"] = (
+            duplicates["_normalized_email"].map(first_occurrence).astype(int)
+        )
+    else:
+        duplicates["source_index"] = pd.Series(dtype=int)
+        duplicates["kept_index"] = pd.Series(dtype=int)
+
+    return clean, duplicates
+
+
+def find_potential_duplicates(
+    df: pd.DataFrame,
+    config: ProcessingConfig,
+    *,
+    threshold: float,
+) -> List[Dict[str, Any]]:
+    """Identify likely duplicates via fuzzy matching on name and city."""
+
+    if "_match_key" not in df.columns:
+        return []
+
+    threshold_score = max(0.0, min(1.0, threshold)) * 100
+    records: List[Dict[str, Any]] = []
+
+    # Prepare blocking to avoid O(n^2) comparisons.
+    blocks: Dict[str, List[int]] = defaultdict(list)
+    for idx, row in df.iterrows():
+        match_key = row["_match_key"]
+        if not isinstance(match_key, str) or not match_key:
+            continue
+        name_norm = row.get("_normalized_name", "")
+        city_norm = row.get("_normalized_city", "")
+        if isinstance(name_norm, str) and name_norm:
+            blocks[f"name:{name_norm[0]}"].append(idx)
+        if isinstance(city_norm, str) and city_norm:
+            blocks[f"city:{city_norm}"].append(idx)
+
+    seen_pairs: set[Tuple[int, int]] = set()
+
+    for indices in blocks.values():
+        if len(indices) < 2:
+            continue
+        unique_indices = sorted(set(indices))
+        for left, right in combinations(unique_indices, 2):
+            pair = (min(left, right), max(left, right))
+            if pair in seen_pairs:
+                continue
+            seen_pairs.add(pair)
+            row_left = df.loc[left]
+            row_right = df.loc[right]
+            key_left = row_left["_match_key"]
+            key_right = row_right["_match_key"]
+            if not key_left or not key_right:
+                continue
+            score = fuzz.token_set_ratio(key_left, key_right)
+            if score < threshold_score:
+                continue
+            normalized_score = round(score / 100.0, 4)
+            note = f"Match key '{key_left}' vs '{key_right}'"
+            records.append(
+                _build_review_record(
+                    row_left,
+                    config,
+                    reason="name+city",
+                    note=note,
+                    other_row=row_right,
+                    score=normalized_score,
+                )
+            )
+
+    return records
+
+
+def prepare_output_frames(
+    clean_df: pd.DataFrame,
+    duplicates_df: pd.DataFrame,
+    review_records: Sequence[Dict[str, Any]],
+    config: ProcessingConfig,
+) -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+    """Prepare DataFrames ready for CSV export without helper columns."""
+
+    helper_cols = [col for col in clean_df.columns if col.startswith("_")]
+
+    clean_output = clean_df.drop(columns=helper_cols, errors="ignore")
+    clean_output = clean_output[config.original_columns]
+
+    duplicates_output = duplicates_df.drop(columns=helper_cols, errors="ignore")
+    duplicates_output = duplicates_output[
+        ["source_index", "kept_index", *config.original_columns]
+    ]
+
+    review_output = pd.DataFrame(list(review_records))
+    if review_output.empty:
+        base_cols = ["reason", "score", "row_index", "other_index", "note"]
+        row_cols = [f"row_{col}" for col in config.original_columns]
+        other_cols = [f"other_{col}" for col in config.original_columns]
+        review_output = pd.DataFrame(columns=[*base_cols, *row_cols, *other_cols])
+
+    return clean_output, duplicates_output, review_output

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+from csv_clean.cli import app
+from csv_clean.processing import (
+    CSVValidationError,
+    ProcessingConfig,
+    apply_normalization,
+    find_potential_duplicates,
+    prepare_output_frames,
+    remove_exact_duplicates,
+    validate_columns,
+)
+from typer.testing import CliRunner
+
+
+def make_config(df: pd.DataFrame) -> ProcessingConfig:
+    return ProcessingConfig(
+        email_col="email",
+        name_col="name",
+        city_col="city",
+        phone_col="phone",
+        original_columns=list(df.columns),
+    )
+
+
+def test_exact_duplicate_removal() -> None:
+    df = pd.DataFrame(
+        {
+            "email": ["alice@example.com", "ALICE@example.com", "bob@example.com"],
+            "name": ["Alice Smith", "Alice Smith", "Bob Brown"],
+            "city": ["Austin", "Austin", "Dallas"],
+            "phone": ["111-222-3333", "111-222-3333", "555-111-0000"],
+        }
+    )
+
+    config = make_config(df)
+    normalized, review_records = apply_normalization(df, config)
+    assert review_records == []
+
+    clean_df, duplicates_df = remove_exact_duplicates(normalized)
+    assert len(clean_df) == 2
+    assert len(duplicates_df) == 1
+    assert duplicates_df.iloc[0]["source_index"] == 1
+    assert duplicates_df.iloc[0]["kept_index"] == 0
+
+    clean_out, duplicates_out, review_out = prepare_output_frames(
+        clean_df, duplicates_df, review_records, config
+    )
+    assert len(clean_out) == 2
+    assert len(duplicates_out) == 1
+    assert review_out.empty
+
+
+def test_fuzzy_matching_threshold_behavior() -> None:
+    df = pd.DataFrame(
+        {
+            "email": ["one@example.com", "two@example.com"],
+            "name": ["Jonathon Doe", "Jonathan Doe"],
+            "city": ["Springfield", "Springfield"],
+            "phone": ["1234567890", "0987654321"],
+        }
+    )
+
+    config = make_config(df)
+    normalized, review_records = apply_normalization(df, config)
+    assert not review_records
+
+    clean_df, duplicates_df = remove_exact_duplicates(normalized)
+    assert duplicates_df.empty
+
+    matches = find_potential_duplicates(clean_df, config, threshold=0.8)
+    assert len(matches) == 1
+    assert matches[0]["reason"] == "name+city"
+
+    strict_matches = find_potential_duplicates(clean_df, config, threshold=0.98)
+    assert strict_matches == []
+
+
+def test_missing_email_column_raises() -> None:
+    df = pd.DataFrame({"name": ["Alice"], "city": ["Austin"]})
+    config = ProcessingConfig(
+        email_col="email",
+        name_col="name",
+        city_col="city",
+        phone_col="phone",
+        original_columns=list(df.columns),
+    )
+
+    with pytest.raises(CSVValidationError):
+        validate_columns(df, config)
+
+
+def test_cli_smoke(tmp_path) -> None:
+    csv_path = tmp_path / "input.csv"
+    csv_path.write_text(
+        "email,name,city\n"
+        "alice@example.com,Alice Smith,Austin\n"
+        "bob@example.com,Bob Brown,Dallas\n"
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "--input",
+            str(csv_path),
+            "--output-dir",
+            str(tmp_path / "out"),
+            "--dry-run",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    output_text = result.stdout or result.stderr
+    assert "Summary" in output_text


### PR DESCRIPTION
## Summary
- add a Typer-based `csv-clean` command that normalizes data, drops invalid emails, removes exact duplicates, and stages fuzzy-review candidates
- implement processing utilities, packaging metadata, CI, and developer tooling for the repo-in-a-box experience
- provide sample CSVs, documentation, and pytest coverage for duplicates, fuzzy thresholds, missing columns, and CLI execution

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_68caddea32c0832d819f9b60e3e9fd60